### PR TITLE
Proposal of temporarily removing Build Status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Noah [![Build Status](http://noah-ci.idylls.jp/job/Noah%20CI/badge/icon)](http://noah-ci.idylls.jp/job/Noah%20CI/)
+# Noah
 
 Noah is a Darwin subsystem for Linux, or "Bash on Ubuntu on Mac OS X". Noah is implemented as a hypervisor that traps linux system calls and translates them into Darwin's system calls. Noah also has an interpreter of ELF files so that binary executables of Linux run directly and flawlessly without any modifications.
 


### PR DESCRIPTION
Not working build status has an negative impact on your project's appearance. 😓 

<img width="298" alt="screen shot 2016-09-26 at 11 34 00" src="https://cloud.githubusercontent.com/assets/155807/18821018/66e06e9c-83dd-11e6-9669-7fdb520941a4.png">

When people stop by this repo, and see this 404, they would feel this project doesn't work well and stop trying even the quick start. 🚧 

I think putting the status budge on README is a good idea, but you should temporarily remove it, and put it again on README when it works. 😸 