### PR TITLE
support macOS High Sierra by removing unnecessary save of VMCS fields

### DIFF
--- a/include/vmm.h
+++ b/include/vmm.h
@@ -11,7 +11,7 @@
 
 struct vcpu_snapshot {
   uint64_t vcpu_reg[NR_X86_REG_LIST];
-  uint64_t vmcs[NR_VMCS_FIELD];
+  uint64_t vmcs[NR_VMCS_FIELD_MASKED];
   char fpu_states[512] __attribute__((aligned(16)));
 };
 

--- a/include/x86/vmx.h
+++ b/include/x86/vmx.h
@@ -1,171 +1,185 @@
 #ifndef NOAH_X86_VMX_H
 #define NOAH_X86_VMX_H
 
-#define NR_VMCS_FIELD (sizeof(vmcs_field_list) / sizeof(uint32_t) - 1)
+#define elementsof(array) ( sizeof(array) / sizeof((array)[0]) )
+#define NR_VMCS_FIELD (elementsof(vmcs_field_list) - 1)
+#define NR_VMCS_FIELD_MASKED (elementsof(vmcs_field_masked_list) - 1)
 
-#define VMCS_FIELD_ENTRIES                      \
-  VMCS_FIELD(VMCS_VPID)                         \
-  VMCS_FIELD(VMCS_CTRL_POSTED_INT_N_VECTOR)     \
-  VMCS_FIELD(VMCS_CTRL_EPTP_INDEX)              \
-  VMCS_FIELD(VMCS_GUEST_ES)                     \
-  VMCS_FIELD(VMCS_GUEST_CS)                     \
-  VMCS_FIELD(VMCS_GUEST_SS)                     \
-  VMCS_FIELD(VMCS_GUEST_DS)                     \
-  VMCS_FIELD(VMCS_GUEST_FS)                     \
-  VMCS_FIELD(VMCS_GUEST_GS)                     \
-  VMCS_FIELD(VMCS_GUEST_LDTR)                   \
-  VMCS_FIELD(VMCS_GUEST_TR)                     \
-  VMCS_FIELD(VMCS_GUEST_INT_STATUS)             \
-  VMCS_FIELD(VMCS_HOST_ES)                      \
-  VMCS_FIELD(VMCS_HOST_CS)                      \
-  VMCS_FIELD(VMCS_HOST_SS)                      \
-  VMCS_FIELD(VMCS_HOST_DS)                      \
-  VMCS_FIELD(VMCS_HOST_FS)                      \
-  VMCS_FIELD(VMCS_HOST_GS)                      \
-  VMCS_FIELD(VMCS_HOST_TR)                      \
-  VMCS_FIELD(VMCS_CTRL_IO_BITMAP_A)             \
-  VMCS_FIELD(VMCS_CTRL_IO_BITMAP_B)             \
-  VMCS_FIELD(VMCS_CTRL_MSR_BITMAPS)             \
-  VMCS_FIELD(VMCS_CTRL_VMEXIT_MSR_STORE_ADDR)   \
-  VMCS_FIELD(VMCS_CTRL_VMEXIT_MSR_LOAD_ADDR)    \
-  VMCS_FIELD(VMCS_CTRL_VMENTRY_MSR_LOAD_ADDR)   \
-  VMCS_FIELD(VMCS_CTRL_EXECUTIVE_VMCS_PTR)      \
-  VMCS_FIELD(VMCS_CTRL_TSC_OFFSET)              \
-  VMCS_FIELD(VMCS_CTRL_VIRTUAL_APIC)            \
-  VMCS_FIELD(VMCS_CTRL_APIC_ACCESS)             \
-  VMCS_FIELD(VMCS_CTRL_POSTED_INT_DESC_ADDR)    \
-  VMCS_FIELD(VMCS_CTRL_VMFUNC_CTRL)             \
-  VMCS_FIELD(VMCS_CTRL_EPTP)                    \
-  VMCS_FIELD(VMCS_CTRL_EOI_EXIT_BITMAP_0)       \
-  VMCS_FIELD(VMCS_CTRL_EOI_EXIT_BITMAP_1)       \
-  VMCS_FIELD(VMCS_CTRL_EOI_EXIT_BITMAP_2)       \
-  VMCS_FIELD(VMCS_CTRL_EOI_EXIT_BITMAP_3)       \
-  VMCS_FIELD(VMCS_CTRL_EPTP_LIST_ADDR)          \
-  VMCS_FIELD(VMCS_CTRL_VMREAD_BITMAP_ADDR)      \
-  VMCS_FIELD(VMCS_CTRL_VMWRITE_BITMAP_ADDR)     \
-  VMCS_FIELD(VMCS_CTRL_VIRT_EXC_INFO_ADDR)      \
-  VMCS_FIELD(VMCS_CTRL_XSS_EXITING_BITMAP)      \
-  VMCS_FIELD(VMCS_GUEST_PHYSICAL_ADDRESS)       \
-  VMCS_FIELD(VMCS_GUEST_LINK_POINTER)           \
-  VMCS_FIELD(VMCS_GUEST_IA32_DEBUGCTL)          \
-  VMCS_FIELD(VMCS_GUEST_IA32_PAT)               \
-  VMCS_FIELD(VMCS_GUEST_IA32_EFER)              \
-  VMCS_FIELD(VMCS_GUEST_IA32_PERF_GLOBAL_CTRL)  \
-  VMCS_FIELD(VMCS_GUEST_PDPTE0)                 \
-  VMCS_FIELD(VMCS_GUEST_PDPTE1)                 \
-  VMCS_FIELD(VMCS_GUEST_PDPTE2)                 \
-  VMCS_FIELD(VMCS_GUEST_PDPTE3)                 \
-  VMCS_FIELD(VMCS_HOST_IA32_PAT)                \
-  VMCS_FIELD(VMCS_HOST_IA32_EFER)               \
-  VMCS_FIELD(VMCS_HOST_IA32_PERF_GLOBAL_CTRL)   \
-  VMCS_FIELD(VMCS_CTRL_PIN_BASED)               \
-  VMCS_FIELD(VMCS_CTRL_CPU_BASED)               \
-  VMCS_FIELD(VMCS_CTRL_EXC_BITMAP)              \
-  VMCS_FIELD(VMCS_CTRL_PF_ERROR_MASK)           \
-  VMCS_FIELD(VMCS_CTRL_PF_ERROR_MATCH)          \
-  VMCS_FIELD(VMCS_CTRL_CR3_COUNT)               \
-  VMCS_FIELD(VMCS_CTRL_VMEXIT_CONTROLS)         \
-  VMCS_FIELD(VMCS_CTRL_VMEXIT_MSR_STORE_COUNT)  \
-  VMCS_FIELD(VMCS_CTRL_VMEXIT_MSR_LOAD_COUNT)   \
-  VMCS_FIELD(VMCS_CTRL_VMENTRY_CONTROLS)        \
-  VMCS_FIELD(VMCS_CTRL_VMENTRY_MSR_LOAD_COUNT)  \
-  VMCS_FIELD(VMCS_CTRL_VMENTRY_IRQ_INFO)        \
-  VMCS_FIELD(VMCS_CTRL_VMENTRY_EXC_ERROR)       \
-  VMCS_FIELD(VMCS_CTRL_VMENTRY_INSTR_LEN)       \
-  VMCS_FIELD(VMCS_CTRL_TPR_THRESHOLD)           \
-  VMCS_FIELD(VMCS_CTRL_CPU_BASED2)              \
-  VMCS_FIELD(VMCS_CTRL_PLE_GAP)                 \
-  VMCS_FIELD(VMCS_CTRL_PLE_WINDOW)              \
-  VMCS_FIELD(VMCS_RO_INSTR_ERROR)               \
-  VMCS_FIELD(VMCS_RO_EXIT_REASON)               \
-  VMCS_FIELD(VMCS_RO_VMEXIT_IRQ_INFO)           \
-  VMCS_FIELD(VMCS_RO_VMEXIT_IRQ_ERROR)          \
-  VMCS_FIELD(VMCS_RO_IDT_VECTOR_INFO)           \
-  VMCS_FIELD(VMCS_RO_IDT_VECTOR_ERROR)          \
-  VMCS_FIELD(VMCS_RO_VMEXIT_INSTR_LEN)          \
-  VMCS_FIELD(VMCS_RO_VMX_INSTR_INFO)            \
-  VMCS_FIELD(VMCS_GUEST_ES_LIMIT)               \
-  VMCS_FIELD(VMCS_GUEST_CS_LIMIT)               \
-  VMCS_FIELD(VMCS_GUEST_SS_LIMIT)               \
-  VMCS_FIELD(VMCS_GUEST_DS_LIMIT)               \
-  VMCS_FIELD(VMCS_GUEST_FS_LIMIT)               \
-  VMCS_FIELD(VMCS_GUEST_GS_LIMIT)               \
-  VMCS_FIELD(VMCS_GUEST_LDTR_LIMIT)             \
-  VMCS_FIELD(VMCS_GUEST_TR_LIMIT)               \
-  VMCS_FIELD(VMCS_GUEST_GDTR_LIMIT)             \
-  VMCS_FIELD(VMCS_GUEST_IDTR_LIMIT)             \
-  VMCS_FIELD(VMCS_GUEST_ES_AR)                  \
-  VMCS_FIELD(VMCS_GUEST_CS_AR)                  \
-  VMCS_FIELD(VMCS_GUEST_SS_AR)                  \
-  VMCS_FIELD(VMCS_GUEST_DS_AR)                  \
-  VMCS_FIELD(VMCS_GUEST_FS_AR)                  \
-  VMCS_FIELD(VMCS_GUEST_GS_AR)                  \
-  VMCS_FIELD(VMCS_GUEST_LDTR_AR)                \
-  VMCS_FIELD(VMCS_GUEST_TR_AR)                  \
-  VMCS_FIELD(VMCS_GUEST_IGNORE_IRQ)             \
-  VMCS_FIELD(VMCS_GUEST_ACTIVITY_STATE)         \
-  VMCS_FIELD(VMCS_GUEST_SMBASE)                 \
-  VMCS_FIELD(VMCS_GUEST_IA32_SYSENTER_CS)       \
-  VMCS_FIELD(VMCS_GUEST_VMX_TIMER_VALUE)        \
-  VMCS_FIELD(VMCS_HOST_IA32_SYSENTER_CS)        \
-  VMCS_FIELD(VMCS_CTRL_CR0_MASK)                \
-  VMCS_FIELD(VMCS_CTRL_CR4_MASK)                \
-  VMCS_FIELD(VMCS_CTRL_CR0_SHADOW)              \
-  VMCS_FIELD(VMCS_CTRL_CR4_SHADOW)              \
-  VMCS_FIELD(VMCS_CTRL_CR3_VALUE0)              \
-  VMCS_FIELD(VMCS_CTRL_CR3_VALUE1)              \
-  VMCS_FIELD(VMCS_CTRL_CR3_VALUE2)              \
-  VMCS_FIELD(VMCS_CTRL_CR3_VALUE3)              \
-  VMCS_FIELD(VMCS_RO_EXIT_QUALIFIC)             \
-  VMCS_FIELD(VMCS_RO_IO_RCX)                    \
-  VMCS_FIELD(VMCS_RO_IO_RSI)                    \
-  VMCS_FIELD(VMCS_RO_IO_RDI)                    \
-  VMCS_FIELD(VMCS_RO_IO_RIP)                    \
-  VMCS_FIELD(VMCS_RO_GUEST_LIN_ADDR)            \
-  VMCS_FIELD(VMCS_GUEST_CR0)                    \
-  VMCS_FIELD(VMCS_GUEST_CR3)                    \
-  VMCS_FIELD(VMCS_GUEST_CR4)                    \
-  VMCS_FIELD(VMCS_GUEST_ES_BASE)                \
-  VMCS_FIELD(VMCS_GUEST_CS_BASE)                \
-  VMCS_FIELD(VMCS_GUEST_SS_BASE)                \
-  VMCS_FIELD(VMCS_GUEST_DS_BASE)                \
-  VMCS_FIELD(VMCS_GUEST_FS_BASE)                \
-  VMCS_FIELD(VMCS_GUEST_GS_BASE)                \
-  VMCS_FIELD(VMCS_GUEST_LDTR_BASE)              \
-  VMCS_FIELD(VMCS_GUEST_TR_BASE)                \
-  VMCS_FIELD(VMCS_GUEST_GDTR_BASE)              \
-  VMCS_FIELD(VMCS_GUEST_IDTR_BASE)              \
-  VMCS_FIELD(VMCS_GUEST_DR7)                    \
-  VMCS_FIELD(VMCS_GUEST_RSP)                    \
-  VMCS_FIELD(VMCS_GUEST_RIP)                    \
-  VMCS_FIELD(VMCS_GUEST_RFLAGS)                 \
-  VMCS_FIELD(VMCS_GUEST_DEBUG_EXC)              \
-  VMCS_FIELD(VMCS_GUEST_SYSENTER_ESP)           \
-  VMCS_FIELD(VMCS_GUEST_SYSENTER_EIP)           \
-  VMCS_FIELD(VMCS_HOST_CR0)                     \
-  VMCS_FIELD(VMCS_HOST_CR3)                     \
-  VMCS_FIELD(VMCS_HOST_CR4)                     \
-  VMCS_FIELD(VMCS_HOST_FS_BASE)                 \
-  VMCS_FIELD(VMCS_HOST_GS_BASE)                 \
-  VMCS_FIELD(VMCS_HOST_TR_BASE)                 \
-  VMCS_FIELD(VMCS_HOST_GDTR_BASE)               \
-  VMCS_FIELD(VMCS_HOST_IDTR_BASE)               \
-  VMCS_FIELD(VMCS_HOST_IA32_SYSENTER_ESP)       \
-  VMCS_FIELD(VMCS_HOST_IA32_SYSENTER_EIP)       \
-  VMCS_FIELD(VMCS_HOST_RSP)                     \
-  VMCS_FIELD(VMCS_HOST_RIP)                     \
+#define VMCS_FIELD_ENTRIES                            \
+  MASK( VMCS_FIELD(VMCS_VPID) )                       \
+  VMCS_FIELD(VMCS_CTRL_POSTED_INT_N_VECTOR)           \
+  VMCS_FIELD(VMCS_CTRL_EPTP_INDEX)                    \
+  VMCS_FIELD(VMCS_GUEST_ES)                           \
+  VMCS_FIELD(VMCS_GUEST_CS)                           \
+  VMCS_FIELD(VMCS_GUEST_SS)                           \
+  VMCS_FIELD(VMCS_GUEST_DS)                           \
+  VMCS_FIELD(VMCS_GUEST_FS)                           \
+  VMCS_FIELD(VMCS_GUEST_GS)                           \
+  VMCS_FIELD(VMCS_GUEST_LDTR)                         \
+  VMCS_FIELD(VMCS_GUEST_TR)                           \
+  VMCS_FIELD(VMCS_GUEST_INT_STATUS)                   \
+  MASK( VMCS_FIELD(VMCS_HOST_ES) )                    \
+  MASK( VMCS_FIELD(VMCS_HOST_CS) )                    \
+  MASK( VMCS_FIELD(VMCS_HOST_SS) )                    \
+  MASK( VMCS_FIELD(VMCS_HOST_DS) )                    \
+  MASK( VMCS_FIELD(VMCS_HOST_FS) )                    \
+  MASK( VMCS_FIELD(VMCS_HOST_GS) )                    \
+  MASK( VMCS_FIELD(VMCS_HOST_TR) )                    \
+  VMCS_FIELD(VMCS_CTRL_IO_BITMAP_A)                   \
+  VMCS_FIELD(VMCS_CTRL_IO_BITMAP_B)                   \
+  VMCS_FIELD(VMCS_CTRL_MSR_BITMAPS)                   \
+  VMCS_FIELD(VMCS_CTRL_VMEXIT_MSR_STORE_ADDR)         \
+  VMCS_FIELD(VMCS_CTRL_VMEXIT_MSR_LOAD_ADDR)          \
+  VMCS_FIELD(VMCS_CTRL_VMENTRY_MSR_LOAD_ADDR)         \
+  VMCS_FIELD(VMCS_CTRL_EXECUTIVE_VMCS_PTR)            \
+  VMCS_FIELD(VMCS_CTRL_TSC_OFFSET)                    \
+  VMCS_FIELD(VMCS_CTRL_VIRTUAL_APIC)                  \
+  VMCS_FIELD(VMCS_CTRL_APIC_ACCESS)                   \
+  VMCS_FIELD(VMCS_CTRL_POSTED_INT_DESC_ADDR)          \
+  VMCS_FIELD(VMCS_CTRL_VMFUNC_CTRL)                   \
+  VMCS_FIELD(VMCS_CTRL_EPTP)                          \
+  VMCS_FIELD(VMCS_CTRL_EOI_EXIT_BITMAP_0)             \
+  VMCS_FIELD(VMCS_CTRL_EOI_EXIT_BITMAP_1)             \
+  VMCS_FIELD(VMCS_CTRL_EOI_EXIT_BITMAP_2)             \
+  VMCS_FIELD(VMCS_CTRL_EOI_EXIT_BITMAP_3)             \
+  VMCS_FIELD(VMCS_CTRL_EPTP_LIST_ADDR)                \
+  VMCS_FIELD(VMCS_CTRL_VMREAD_BITMAP_ADDR)            \
+  VMCS_FIELD(VMCS_CTRL_VMWRITE_BITMAP_ADDR)           \
+  VMCS_FIELD(VMCS_CTRL_VIRT_EXC_INFO_ADDR)            \
+  VMCS_FIELD(VMCS_CTRL_XSS_EXITING_BITMAP)            \
+  MASK( VMCS_FIELD(VMCS_GUEST_PHYSICAL_ADDRESS) )     \
+  VMCS_FIELD(VMCS_GUEST_LINK_POINTER)                 \
+  VMCS_FIELD(VMCS_GUEST_IA32_DEBUGCTL)                \
+  VMCS_FIELD(VMCS_GUEST_IA32_PAT)                     \
+  VMCS_FIELD(VMCS_GUEST_IA32_EFER)                    \
+  VMCS_FIELD(VMCS_GUEST_IA32_PERF_GLOBAL_CTRL)        \
+  VMCS_FIELD(VMCS_GUEST_PDPTE0)                       \
+  VMCS_FIELD(VMCS_GUEST_PDPTE1)                       \
+  VMCS_FIELD(VMCS_GUEST_PDPTE2)                       \
+  VMCS_FIELD(VMCS_GUEST_PDPTE3)                       \
+  MASK( VMCS_FIELD(VMCS_HOST_IA32_PAT) )              \
+  MASK( VMCS_FIELD(VMCS_HOST_IA32_EFER) )             \
+  MASK( VMCS_FIELD(VMCS_HOST_IA32_PERF_GLOBAL_CTRL) ) \
+  VMCS_FIELD(VMCS_CTRL_PIN_BASED)                     \
+  VMCS_FIELD(VMCS_CTRL_CPU_BASED)                     \
+  VMCS_FIELD(VMCS_CTRL_EXC_BITMAP)                    \
+  VMCS_FIELD(VMCS_CTRL_PF_ERROR_MASK)                 \
+  VMCS_FIELD(VMCS_CTRL_PF_ERROR_MATCH)                \
+  VMCS_FIELD(VMCS_CTRL_CR3_COUNT)                     \
+  VMCS_FIELD(VMCS_CTRL_VMEXIT_CONTROLS)               \
+  VMCS_FIELD(VMCS_CTRL_VMEXIT_MSR_STORE_COUNT)        \
+  VMCS_FIELD(VMCS_CTRL_VMEXIT_MSR_LOAD_COUNT)         \
+  VMCS_FIELD(VMCS_CTRL_VMENTRY_CONTROLS)              \
+  VMCS_FIELD(VMCS_CTRL_VMENTRY_MSR_LOAD_COUNT)        \
+  VMCS_FIELD(VMCS_CTRL_VMENTRY_IRQ_INFO)              \
+  VMCS_FIELD(VMCS_CTRL_VMENTRY_EXC_ERROR)             \
+  VMCS_FIELD(VMCS_CTRL_VMENTRY_INSTR_LEN)             \
+  VMCS_FIELD(VMCS_CTRL_TPR_THRESHOLD)                 \
+  VMCS_FIELD(VMCS_CTRL_CPU_BASED2)                    \
+  VMCS_FIELD(VMCS_CTRL_PLE_GAP)                       \
+  VMCS_FIELD(VMCS_CTRL_PLE_WINDOW)                    \
+  MASK( VMCS_FIELD(VMCS_RO_INSTR_ERROR) )             \
+  MASK( VMCS_FIELD(VMCS_RO_EXIT_REASON) )             \
+  MASK( VMCS_FIELD(VMCS_RO_VMEXIT_IRQ_INFO) )         \
+  MASK( VMCS_FIELD(VMCS_RO_VMEXIT_IRQ_ERROR) )        \
+  MASK( VMCS_FIELD(VMCS_RO_IDT_VECTOR_INFO) )         \
+  MASK( VMCS_FIELD(VMCS_RO_IDT_VECTOR_ERROR) )        \
+  MASK( VMCS_FIELD(VMCS_RO_VMEXIT_INSTR_LEN) )        \
+  MASK( VMCS_FIELD(VMCS_RO_VMX_INSTR_INFO) )          \
+  VMCS_FIELD(VMCS_GUEST_ES_LIMIT)                     \
+  VMCS_FIELD(VMCS_GUEST_CS_LIMIT)                     \
+  VMCS_FIELD(VMCS_GUEST_SS_LIMIT)                     \
+  VMCS_FIELD(VMCS_GUEST_DS_LIMIT)                     \
+  VMCS_FIELD(VMCS_GUEST_FS_LIMIT)                     \
+  VMCS_FIELD(VMCS_GUEST_GS_LIMIT)                     \
+  VMCS_FIELD(VMCS_GUEST_LDTR_LIMIT)                   \
+  VMCS_FIELD(VMCS_GUEST_TR_LIMIT)                     \
+  VMCS_FIELD(VMCS_GUEST_GDTR_LIMIT)                   \
+  VMCS_FIELD(VMCS_GUEST_IDTR_LIMIT)                   \
+  VMCS_FIELD(VMCS_GUEST_ES_AR)                        \
+  VMCS_FIELD(VMCS_GUEST_CS_AR)                        \
+  VMCS_FIELD(VMCS_GUEST_SS_AR)                        \
+  VMCS_FIELD(VMCS_GUEST_DS_AR)                        \
+  VMCS_FIELD(VMCS_GUEST_FS_AR)                        \
+  VMCS_FIELD(VMCS_GUEST_GS_AR)                        \
+  VMCS_FIELD(VMCS_GUEST_LDTR_AR)                      \
+  VMCS_FIELD(VMCS_GUEST_TR_AR)                        \
+  VMCS_FIELD(VMCS_GUEST_IGNORE_IRQ)                   \
+  VMCS_FIELD(VMCS_GUEST_ACTIVITY_STATE)               \
+  VMCS_FIELD(VMCS_GUEST_SMBASE)                       \
+  VMCS_FIELD(VMCS_GUEST_IA32_SYSENTER_CS)             \
+  VMCS_FIELD(VMCS_GUEST_VMX_TIMER_VALUE)              \
+  VMCS_FIELD(VMCS_HOST_IA32_SYSENTER_CS)              \
+  VMCS_FIELD(VMCS_CTRL_CR0_MASK)                      \
+  VMCS_FIELD(VMCS_CTRL_CR4_MASK)                      \
+  VMCS_FIELD(VMCS_CTRL_CR0_SHADOW)                    \
+  VMCS_FIELD(VMCS_CTRL_CR4_SHADOW)                    \
+  VMCS_FIELD(VMCS_CTRL_CR3_VALUE0)                    \
+  VMCS_FIELD(VMCS_CTRL_CR3_VALUE1)                    \
+  VMCS_FIELD(VMCS_CTRL_CR3_VALUE2)                    \
+  VMCS_FIELD(VMCS_CTRL_CR3_VALUE3)                    \
+  MASK( VMCS_FIELD(VMCS_RO_EXIT_QUALIFIC) )           \
+  MASK( VMCS_FIELD(VMCS_RO_IO_RCX) )                  \
+  MASK( VMCS_FIELD(VMCS_RO_IO_RSI) )                  \
+  MASK( VMCS_FIELD(VMCS_RO_IO_RDI) )                  \
+  MASK( VMCS_FIELD(VMCS_RO_IO_RIP) )                  \
+  MASK( VMCS_FIELD(VMCS_RO_GUEST_LIN_ADDR) )          \
+  VMCS_FIELD(VMCS_GUEST_CR0)                          \
+  VMCS_FIELD(VMCS_GUEST_CR3)                          \
+  VMCS_FIELD(VMCS_GUEST_CR4)                          \
+  VMCS_FIELD(VMCS_GUEST_ES_BASE)                      \
+  VMCS_FIELD(VMCS_GUEST_CS_BASE)                      \
+  VMCS_FIELD(VMCS_GUEST_SS_BASE)                      \
+  VMCS_FIELD(VMCS_GUEST_DS_BASE)                      \
+  VMCS_FIELD(VMCS_GUEST_FS_BASE)                      \
+  VMCS_FIELD(VMCS_GUEST_GS_BASE)                      \
+  VMCS_FIELD(VMCS_GUEST_LDTR_BASE)                    \
+  VMCS_FIELD(VMCS_GUEST_TR_BASE)                      \
+  VMCS_FIELD(VMCS_GUEST_GDTR_BASE)                    \
+  VMCS_FIELD(VMCS_GUEST_IDTR_BASE)                    \
+  VMCS_FIELD(VMCS_GUEST_DR7)                          \
+  VMCS_FIELD(VMCS_GUEST_RSP)                          \
+  VMCS_FIELD(VMCS_GUEST_RIP)                          \
+  VMCS_FIELD(VMCS_GUEST_RFLAGS)                       \
+  VMCS_FIELD(VMCS_GUEST_DEBUG_EXC)                    \
+  VMCS_FIELD(VMCS_GUEST_SYSENTER_ESP)                 \
+  VMCS_FIELD(VMCS_GUEST_SYSENTER_EIP)                 \
+  MASK( VMCS_FIELD(VMCS_HOST_CR0) )                   \
+  MASK( VMCS_FIELD(VMCS_HOST_CR3) )                   \
+  MASK( VMCS_FIELD(VMCS_HOST_CR4) )                   \
+  MASK( VMCS_FIELD(VMCS_HOST_FS_BASE) )               \
+  MASK( VMCS_FIELD(VMCS_HOST_GS_BASE) )               \
+  MASK( VMCS_FIELD(VMCS_HOST_TR_BASE) )               \
+  MASK( VMCS_FIELD(VMCS_HOST_GDTR_BASE) )             \
+  MASK( VMCS_FIELD(VMCS_HOST_IDTR_BASE) )             \
+  MASK( VMCS_FIELD(VMCS_HOST_IA32_SYSENTER_ESP) )     \
+  MASK( VMCS_FIELD(VMCS_HOST_IA32_SYSENTER_EIP) )     \
+  MASK( VMCS_FIELD(VMCS_HOST_RSP) )                   \
+  MASK( VMCS_FIELD(VMCS_HOST_RIP) )                   \
   VMCS_FIELD(VMCS_MAX)
 
 static const uint32_t vmcs_field_list[] = {
+#define MASK(x) x
 #define VMCS_FIELD(x) x,
   VMCS_FIELD_ENTRIES
 #undef VMCS_FIELD
+#undef MASK
 };
 
 static const char *vmcs_field_str[] = {
+#define MASK(x) x
 #define VMCS_FIELD(x) #x,
   VMCS_FIELD_ENTRIES
 #undef VMCS_FIELD
+#undef MASK
+};
+
+static const uint32_t vmcs_field_masked_list[] = {
+#define MASK(x)
+#define VMCS_FIELD(x) x,
+  VMCS_FIELD_ENTRIES
+#undef VMCS_FIELD
+#undef MASK
 };
 
 #define NR_X86_REG_LIST (sizeof(x86_reg_list) / sizeof(uint32_t) - 1)

--- a/lib/vmm.c
+++ b/lib/vmm.c
@@ -207,8 +207,8 @@ vmm_snapshot_vcpu(struct vcpu_snapshot *snapshot)
     vmm_read_register(x86_reg_list[i], &snapshot->vcpu_reg[i]);
   }
   /* snapshot vmcs */
-  for (uint64_t i = 0; i < NR_VMCS_FIELD; i++) {
-    vmm_read_vmcs(vmcs_field_list[i], &snapshot->vmcs[i]);
+  for (uint64_t i = 0; i < NR_VMCS_FIELD_MASKED; i++) {
+    vmm_read_vmcs(vmcs_field_masked_list[i], &snapshot->vmcs[i]);
   }
   hv_vcpu_read_fpstate(vcpu->vcpuid, snapshot->fpu_states, sizeof snapshot->fpu_states);
 }
@@ -236,55 +236,8 @@ void
 vmm_restore_vcpu(struct vcpu_snapshot *snapshot)
 {
   /* restore vmcs */
-  static const uint32_t restore_mask[] = {
-    VMCS_VPID,
-    VMCS_HOST_ES,
-    VMCS_HOST_CS,
-    VMCS_HOST_SS,
-    VMCS_HOST_DS,
-    VMCS_HOST_FS,
-    VMCS_HOST_GS,
-    VMCS_HOST_TR,
-    VMCS_HOST_IA32_PAT,
-    VMCS_HOST_IA32_EFER,
-    VMCS_HOST_IA32_PERF_GLOBAL_CTRL,
-    VMCS_GUEST_PHYSICAL_ADDRESS,
-    VMCS_RO_INSTR_ERROR,
-    VMCS_RO_EXIT_REASON,
-    VMCS_RO_VMEXIT_IRQ_INFO,
-    VMCS_RO_VMEXIT_IRQ_ERROR,
-    VMCS_RO_IDT_VECTOR_INFO,
-    VMCS_RO_IDT_VECTOR_ERROR,
-    VMCS_RO_VMEXIT_INSTR_LEN,
-    VMCS_RO_VMX_INSTR_INFO,
-    VMCS_RO_EXIT_QUALIFIC,
-    VMCS_RO_IO_RCX,
-    VMCS_RO_IO_RSI,
-    VMCS_RO_IO_RDI,
-    VMCS_RO_IO_RIP,
-    VMCS_RO_GUEST_LIN_ADDR,
-    VMCS_HOST_CR0,
-    VMCS_HOST_CR3,
-    VMCS_HOST_CR4,
-    VMCS_HOST_FS_BASE,
-    VMCS_HOST_GS_BASE,
-    VMCS_HOST_TR_BASE,
-    VMCS_HOST_GDTR_BASE,
-    VMCS_HOST_IDTR_BASE,
-    VMCS_HOST_IA32_SYSENTER_ESP,
-    VMCS_HOST_IA32_SYSENTER_EIP,
-    VMCS_HOST_RSP,
-    VMCS_HOST_RIP,
-  };
-
-  for (uint64_t i = 0; i < NR_VMCS_FIELD; i++) {
-    for (uint64_t j = 0; j < sizeof restore_mask / sizeof restore_mask[0]; j++) {
-      if (restore_mask[j] == vmcs_field_list[i]) {
-        goto cont;
-      }
-    }
-    vmm_write_vmcs(vmcs_field_list[i], snapshot->vmcs[i]);
-cont: ;
+  for (uint64_t i = 0; i < NR_VMCS_FIELD_MASKED; i++) {
+    vmm_write_vmcs(vmcs_field_masked_list[i], snapshot->vmcs[i]);
   }
 
   /* restore registers */


### PR DESCRIPTION
macOS High Sierra does not allow to read VMCS_HOST_IA32_SYSENTER_ESP and VMCS_HOST_IA32_SYSENTER_EIP. But noah tries to read these field on making a snapshot, although they are not restored.

This patch makes a new list, vmcs_field_masked_list. noah now saves and restores only necessary VMCS fields.