### PR TITLE
Preserve rbx regsiter when cpuid is called.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -145,7 +145,7 @@ main_loop(int return_on_sigret)
 	  vmm_read_register(HV_X86_XCR0, &xcr0);
 	  if ((xcr0 & XCR0_AVX_STATE) == 0) {
 	    uint64_t eax;
-	    asm ("cpuid" : "=a" (eax) : "a" (0x0d), "c" (0));
+	    asm ("cpuid" : "=a" (eax) : "a" (0x0d), "c" (0) : "rbx");
 	    if (eax & XCR0_AVX_STATE) {
 	      vmm_write_register(HV_X86_XCR0, xcr0 | XCR0_AVX_STATE);
 	      continue;
@@ -331,7 +331,7 @@ init_regs()
   /* set up cpu regs */
   vmm_write_register(HV_X86_RFLAGS, 0x2);
   uint64_t eax;
-  asm ("cpuid" : "=a" (eax) : "a" (0x0d), "c" (0));
+  asm ("cpuid" : "=a" (eax) : "a" (0x0d), "c" (0): "rbx");
   if (eax & XCR0_SSE_STATE) {
     uint64_t xcr0;
     vmm_read_register(HV_X86_XCR0, &xcr0);


### PR DESCRIPTION
x86-64 uses rbx as the base register, so preserve it. Fix #56.