### PR TITLE
Add support for MSG_NOSIGNAL flag in sendmsg and sendmmsg

### DIFF
--- a/src/net/net.c
+++ b/src/net/net.c
@@ -401,7 +401,7 @@ do_sendmsg(int sockfd, const struct l_msghdr *msg, int flags)
     int r = syswrap(setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE,
 			       (void*)&val, sizeof(val)));
     if (r < 0) {
-      return r;
+      panic("Noah cannot set SO_NOSIGPIPE option.");
     }
   }
 


### PR DESCRIPTION
I added support for MSG_NOSIGNAL flag in sendmsg and sendmmsg.
Please review this PR.

This PR makes that the getaddrinfo function works correctly.
I tested this by the following python3 code.

```
import socket

infolist = socket.getaddrinfo('google.com', 'www')
print(infolist)
```

