### PR TITLE
Fix print gstr crash

### DIFF
--- a/src/meta_strace.c
+++ b/src/meta_strace.c
@@ -29,7 +29,7 @@ print_gstr(gstr_t str, int maxlen)
 {
   fprintf(strace_sink, "\"");
   for (int i = 0; i < maxlen; i++) {
-    char c = *((char*)guest_to_host(str) + i);
+    char c = *((char*)guest_to_host(str + i));
     if (c == '\0') {
       break;
     } else if (c == '\n') {


### PR DESCRIPTION
When the string memory of the guest OS is allocated to two areas on the host OS, 
print_gstr function will crash.
This PR is to fix this issue.

Please review this.