### PR TITLE
Add LOOKUP_NOFOLLOW option to the newpath

### DIFF
--- a/src/fs/fs.c
+++ b/src/fs/fs.c
@@ -1451,7 +1451,7 @@ DEFINE_SYSCALL(renameat, int, oldfd, gstr_t, oldpath_ptr, int, newfd, gstr_t, ne
   if ((r = vfs_grab_dir(oldfd, oldname, LOOKUP_NOFOLLOW, &oldpath)) < 0) {
     goto out1;
   }
-  if ((r = vfs_grab_dir(newfd, newname, 0, &newpath)) < 0) {
+  if ((r = vfs_grab_dir(newfd, newname, LOOKUP_NOFOLLOW, &newpath)) < 0) {
     goto out2;
   }
   if (oldpath.fs != newpath.fs) {


### PR DESCRIPTION
Add LOOKUP_NOFOLLOW option to find the new path in renameat function.

If newpath refers to a symoblic link, the renameat function renames a file, not a symbolic link.  
This PR modifies the renameat function to overwrite the symbolic link if newpath refers to a symbolic link.

Please review this.