### PR TITLE
Remove copy_to_user from pwrite64

### DIFF
--- a/src/fs/fs.c
+++ b/src/fs/fs.c
@@ -1858,10 +1858,6 @@ DEFINE_SYSCALL(pwrite64, unsigned int, fd, gstr_t, buf_ptr, size_t, count, off_t
   if (r < 0) {
     goto out;
   }
-  if (copy_to_user(buf_ptr, buf, r)) {
-    r = -LINUX_EFAULT;
-    goto out;
-  }
 out:
   free(buf);
   return r;


### PR DESCRIPTION
pwrite64 system call defines the following:
```
ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
```
Because the argument buf is ```const void*```,  there is no need to copy to user.
 
This PR fixes not to call copy_to_user in pwrite64.