### PR TITLE
Fix crash when directory is specified in elf path

### DIFF
--- a/src/proc/exec.c
+++ b/src/proc/exec.c
@@ -400,10 +400,14 @@ do_exec(const char *elf_path, int argc, char *argv[], char **envp)
     return -LINUX_EINVAL;
   }
 
-  prepare_newproc();
-
   /* Now do exec */
   fstat(fd, &st);
+  if (!S_ISREG(st.st_mode)) {
+    vkern_close(fd);
+    return -LINUX_EACCES;
+  }
+
+  prepare_newproc();
 
   data = mmap(0, st.st_size, PROT_READ | PROT_EXEC, MAP_PRIVATE, fd, 0);
 


### PR DESCRIPTION
When a directory is specified in the elf path, the execeve system call will crash in noah.
You can reproduce this issue in the following procedure.

1. Open /bin/bash in the noah
2. Input "/"

This PR will fix above issue.
Could you review this?

